### PR TITLE
feat(repo): establish canonical label governance

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,57 @@
+[
+  {
+    "name": "type:feature",
+    "color": "1f6feb",
+    "description": "New user-facing capability or repository feature",
+  },
+  {
+    "name": "type:fix",
+    "color": "d73a4a",
+    "description": "Bug fix or correction",
+  },
+  {
+    "name": "type:docs",
+    "color": "0e8a16",
+    "description": "Documentation-only change",
+  },
+  {
+    "name": "type:chore",
+    "color": "6f42c1",
+    "description": "Maintenance, housekeeping, or non-functional repo work",
+  },
+  {
+    "name": "type:ci",
+    "color": "5319e7",
+    "description": "Continuous integration or automation workflow change",
+  },
+  {
+    "name": "status:blocked",
+    "color": "b60205",
+    "description": "Work cannot proceed until dependency or decision is resolved",
+  },
+  {
+    "name": "status:needs-review",
+    "color": "fbca04",
+    "description": "Ready for reviewer attention",
+  },
+  {
+    "name": "priority:high",
+    "color": "d93f0b",
+    "description": "High priority work",
+  },
+  {
+    "name": "priority:medium",
+    "color": "fbca04",
+    "description": "Normal priority work",
+  },
+  {
+    "name": "priority:low",
+    "color": "0e8a16",
+    "description": "Low priority work",
+  },
+  {
+    "name": "bootstrap",
+    "color": "1d76db",
+    "description": "Repository bootstrap and foundation work",
+  },
+]

--- a/scripts/sync_labels.sh
+++ b/scripts/sync_labels.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="${1:-$(gh repo view --json nameWithOwner --jq '.nameWithOwner')}"
+LABEL_FILE=".github/labels.yml"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh CLI is required" >&2
+  exit 1
+fi
+
+if [[ ! -f "$LABEL_FILE" ]]; then
+  echo "Missing $LABEL_FILE" >&2
+  exit 1
+fi
+
+python3 - "$LABEL_FILE" <<'PY' | while IFS=$'\t' read -r name color description; do
+import sys
+
+try:
+    import yaml
+except ImportError:
+    print("PyYAML is required. Install it with: python3 -m pip install pyyaml", file=sys.stderr)
+    sys.exit(1)
+
+with open(sys.argv[1], encoding="utf-8") as fh:
+    labels = yaml.safe_load(fh)
+
+for label in labels:
+    print(f"{label['name']}\t{label['color']}\t{label['description']}")
+PY
+  gh label create "$name" \
+    --repo "$REPO" \
+    --color "$color" \
+    --description "$description" \
+    --force
+  echo "synced: $name"
+done


### PR DESCRIPTION
Closes #8

Adds canonical label definitions and synchronization tooling.

Includes:
- .github/labels.yml label source of truth
- scripts/sync_labels.sh label synchronization script

This allows repository labels to be bootstrapped and kept consistent across environments.