### PR TITLE
chore(repo): add pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,39 @@
+repos:
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.41.0
+    hooks:
+      - id: markdownlint
+        args: ["--fix", "**/*.md"]
+
+  # ------------------------------------------------------------
+  # Basic hygiene
+  # ------------------------------------------------------------
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: check-merge-conflict
+
+  # ------------------------------------------------------------
+  # YAML linting
+  # ------------------------------------------------------------
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.37.1
+    hooks:
+      - id: yamllint
+        files: \.(yml|yaml)$
+
+  # ------------------------------------------------------------
+  # Ruff (Python)
+  # ------------------------------------------------------------
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.9
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+        files: \.py$
+      - id: ruff-format
+        files: \.py$


### PR DESCRIPTION
Closes #21

## Summary
Adds a repository `.pre-commit-config.yaml` to restore local commit hooks and baseline quality enforcement.

## Changes
- adds markdownlint with autofix for Markdown
- adds basic pre-commit hygiene hooks
- adds yamllint for YAML files
- adds ruff and ruff-format for Python files

## Testing
- ran `pre-commit install`
- ran `pre-commit run --all-files`

## Notes
This restores local hook behavior so checks run during commit instead of relying on vibes and optimism.
