### PR TITLE
feat(release): add Commitizen bump and changelog workflow

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -1,0 +1,34 @@
+name: Bump Version
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  bump_version:
+    if: "!startsWith(github.event.head_commit.message, 'bump:')"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Bump version and changelog
+        id: cz
+        uses: commitizen-tools/commitizen-action@master
+        with:
+          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Show outputs
+        run: |
+          echo "Version: ${{ steps.cz.outputs.version }}"
+          echo "Tag: ${{ steps.cz.outputs.tag }}"


### PR DESCRIPTION
Closes #16

## Summary
Adds a Commitizen-based workflow to automate version bumping and changelog generation.

## Motivation
Manual version management is error-prone and slows down release hygiene. Automating the process improves consistency.

## Changes
- adds `.github/workflows/bumpversion.yml`

## Benefits
- automated semantic versioning
- improved changelog consistency
- reduced manual release overhead

## Risk Level
- [x] Low – isolated CI/release change
- [ ] Medium – affects multiple areas
- [ ] High – core workflow change

## Testing / Validation
- reviewed workflow syntax
- confirmed workflow is scoped to release automation
- validated compatibility with Commitizen config

## Rollback Plan
Revert this PR to remove automated version bumping and changelog generation.

## Notes
This workflow depends on the Commitizen configuration added in #15.
