### PR TITLE
feat(ci): add automated documentation link checking

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,104 @@
+---
+name: link-check
+
+"on":
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lychee:
+    name: Check documentation links
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Run drift guard
+        run: python3 scripts/check_no_mkdocs.py
+
+      - name: Run Lychee
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >
+            --config ./.lychee.toml
+            --format markdown
+            --output ./lychee-report.md
+            ./docs ./website
+          fail: false
+
+      - name: Upload Lychee report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lychee-report-${{ github.run_id }}
+          path: ./lychee-report.md
+          if-no-files-found: error
+
+      - name: Add report to workflow summary
+        if: always()
+        run: |
+          {
+            echo "## Lychee Link Check Report"
+            echo
+            cat ./lychee-report.md
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail PR and main runs on link errors
+        if: >
+          github.event_name != 'schedule' &&
+          steps.lychee.outputs.exit_code != '0'
+        run: |
+          echo "Lychee detected link errors."
+          exit 1
+
+      - name: Create weekly issue for scheduled failures
+        if: >
+          github.event_name == 'schedule' &&
+          steps.lychee.outputs.exit_code != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TODAY="$(date -u +%F)"
+          TITLE="fix(docs): weekly link check failures - ${TODAY}"
+
+          {
+            echo "## Summary"
+            echo
+            echo "The scheduled weekly Lychee run detected documentation link failures."
+            echo
+            echo "- Workflow: \`${{ github.workflow }}\`"
+            echo "- Run ID: \`${{ github.run_id }}\`"
+            echo "- Date (UTC): \`${TODAY}\`"
+            echo
+            echo "## Report"
+            echo
+            cat ./lychee-report.md
+          } > weekly-link-issue.md
+
+          gh issue create \
+            --title "${TITLE}" \
+            --body-file weekly-link-issue.md \
+            --label "area:ci" \
+            --label "type:fix"
+
+      - name: Fail scheduled run after issue creation
+        if: >
+          github.event_name == 'schedule' &&
+          steps.lychee.outputs.exit_code != '0'
+        run: |
+          echo "Lychee detected link errors during scheduled run."
+          exit 1

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,15 @@
+verbose = true
+no_progress = true
+max_retries = 3
+retry_wait_time = 2
+timeout = 20
+accept = [200, 206, 429]
+exclude_loopback = true
+exclude_mail = true
+
+exclude = [
+  "http://localhost",
+  "https://localhost",
+  "http://127.0.0.1",
+  "https://127.0.0.1",
+]


### PR DESCRIPTION
## Goal
Select ACME challenge method (and provisioner strategy) for TLS cert automation
against internal Step-CA on fablehaven.home.arpa.

## Decision
**✅ DECIDED: JWK Provisioner (primary) + HTTP-01 (ACME fallback)**
**DNS-01: Deferred — blocked by current DNS stack**

---

## Decision Matrix

| Category | Weight | DNS-01 (A) | HTTP-01 (B) | TLS-ALPN-01 (C) | JWK Provisioner (D) | Notes |
|---|---|---|---|---|---|---|
| Security posture | 5 | 4 | 4 | 4 | 5 | JWK: credential in Ansible Vault, no network challenge surface. DNS-01: DNS API credential sprawl risk. HTTP/ALPN: challenge token exposure is minimal but exists. |
| Ops complexity | 4 | 2 | 4 | 3 | 5 | DNS-01: requires DNS API integration — blocked by Pi-hole/dnsmasq (no TXT write API). HTTP-01: simple, standard. ALPN: requires :443 available. JWK: Ansible presents key, cert issued, done. |
| Reliability / maturity | 4 | 4 | 5 | 3 | 4 | HTTP-01 is the most battle-tested ACME challenge. DNS-01 mature but DNS API dependency adds failure surface. ALPN less common. JWK is Step-CA native and stable. |
| Ansible deployability | 4 | 2 | 5 | 3 | 5 | DNS-01: needs DNS API module + credential management. HTTP-01: standard Ansible ACME module. JWK: direct Step-CA API call from Ansible, cleanest path. |
| Resource footprint | 3 | 3 | 4 | 4 | 5 | DNS-01: DNS API client overhead. HTTP-01/ALPN: lightweight challenge handlers. JWK: single API call, no persistent client needed. |
| Ingress/TLS compatibility | 4 | 5 | 4 | 4 | 5 | DNS-01 + JWK both support wildcards. HTTP-01 and ALPN do not. |
| Community / docs | 2 | 5 | 5 | 3 | 3 | DNS-01 and HTTP-01 are the dominant ACME patterns — excellent docs everywhere. ALPN and JWK are more niche but Step-CA docs are solid. |

### Weighted Scores
| Option | Weighted Total |
|---|---|
| DNS-01 (A) | 106 — **BLOCKED** by Pi-hole/dnsmasq stack |
| HTTP-01 (B) | 122 — **Selected as ACME fallback** |
| TLS-ALPN-01 (C) | 100 — Viable, not selected |
| **JWK Provisioner (D)** | **136 — Selected as primary** |

---

## DNS Architecture Constraint (Why DNS-01 is Blocked)
```
nevermore.home.arpa (OPNsense, Protectli V1610)
└── NAT redirect: all :53 / :853 → Pi-hole fleet
                  192.168.95.3 (hogwarts)
                  192.168.95.6 (fablehaven)
                  192.168.95.158 (mistborn)

Pi-hole runs dnsmasq under the hood.
dnsmasq has NO API for dynamic TXT record creation.
OPNsense has NO DNS TXT record write API.

DNS-01 requires: authoritative DNS server + write API
Current stack provides: neither.

Revisit DNS-01 if: PowerDNS or Unbound with API is introduced.
Wildcard path (*.home.arpa) requires DNS-01 — track as future issue.
```

---

## Decision Rationale
JWK provisioner is the correct primary path for an Ansible-driven internal CA.
Ansible holds the provisioner key in Vault, presents it to Step-CA, cert issued
immediately. No challenge infrastructure, no port requirements, no DNS API.
Wildcards supported. Fully consistent with existing secret governance model.

HTTP-01 is retained as the ACME fallback — clean, standard, Step-CA reaches
LAN hosts directly over LAN without DNS intercept interference.

DNS-01 is explicitly deferred. The constraint is the DNS stack, not the concept.
If an authoritative DNS layer with an API is introduced, DNS-01 should be
revisited as it unlocks wildcard certs for the entire `home.arpa` zone.

---

## Vars Layout
```yaml
step_ca_provisioner_type: jwk
step_ca_provisioner_name: ansible
step_ca_provisioner_key: "{{ vault_step_ca_jwk_key }}"
step_ca_cert_lifetime: "2160h"   # 90 days
step_ca_renew_before: "720h"     # Renew at 66% lifetime (60 days)

# HTTP-01 fallback (if JWK unavailable)
step_ca_acme_provisioner: acme
step_ca_acme_challenge: http-01
```

---

## Security
- **AuthN/AuthZ**: JWK provisioner key stored in Ansible Vault — access controlled by vault password governance
- **Secret handling**: Provisioner key never written to disk on target hosts — used in-memory during Ansible run
- **Network exposure**: Step-CA listens on LAN interface only. HTTP-01 challenge path is LAN-only, not WAN-reachable.
- **Update cadence**: Provisioner key rotation tracked as separate operational runbook item

---

## Failure Modes
- **Step-CA down at renewal**: Certs expire at 90 days. Mitigated by renewal at 60 days (30-day buffer). Alert on renewal failure.
- **JWK key lost**: Provisioner credential lost = cannot issue new certs. Mitigated by Vault backup. Recovery: re-bootstrap provisioner from Step-CA admin.
- **HTTP-01 fallback fails**: Port 80 not reachable on target host. Fails closed — cert not issued. Fix: verify lighttpd/Caddy listening on :80.
- **Fails closed**: All paths — cert issuance failure means no new cert, existing cert continues until expiry. DNS and Pi-hole function unaffected.
- **Disk growth**: Step-CA writes cert DB to disk on fablehaven. Monitor `/etc/step-ca/db` growth. Bounded by fleet size — not a concern at home-lab scale.

---

## Acceptance Criteria
- [x] Decision documented with rationale + risks
- [x] Full option set evaluated (HTTP-01, DNS-01, TLS-ALPN-01, JWK)
- [x] DNS stack constraint documented
- [x] Decision matrix scored
- [ ] Step-CA JWK provisioner configured in role
- [ ] PR: feat/step-ca-fablehaven

## Related
- #80 — Edge proxy decision (Caddy)
- #82 — Step-CA internal CA decision