### PR TITLE
fix(ci): narrow cspell scope and add repo dictionary words

### DIFF
--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
-      - name: Run CSpell on changed files
+      - name: Run CSpell on changed markdown and MDX files
         if: github.event_name == 'pull_request'
         uses: streetsidesoftware/cspell-action@v8
         with:
@@ -37,10 +37,8 @@ jobs:
           files: |
             **/*.md
             **/*.mdx
-            docs/**
-            website/**
 
-      - name: Run CSpell on full docs surface
+      - name: Run CSpell on full markdown and MDX surface
         if: github.event_name != 'pull_request'
         uses: streetsidesoftware/cspell-action@v8
         with:
@@ -49,5 +47,3 @@ jobs:
           files: |
             **/*.md
             **/*.mdx
-            docs/**
-            website/**

--- a/config/cspell-dictionary.txt
+++ b/config/cspell-dictionary.txt
@@ -13,7 +13,6 @@ PRs
 repo
 repos
 CI
-Netlify
 markdownlint
 frontmatter
 front-matter
@@ -22,3 +21,7 @@ pathname
 newcomb
 labs
 kotahukka
+Zettelkasten
+zettel
+mocs
+Backlinks

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -11,22 +11,24 @@ dictionaryDefinitions:
 dictionaries:
   - repo-words
 
+files:
+  - "**/*.md"
+  - "**/*.mdx"
+
 ignorePaths:
   - node_modules/**
   - build/**
   - .docusaurus/**
   - .git/**
-  - .github/**/*.svg
   - website/build/**
   - website/.docusaurus/**
-  - "*.lock"
+  - website/static/img/**
+  - "**/*.svg"
+  - "**/*.js"
+  - "**/*.ts"
+  - "**/*.tsx"
+  - "**/*.lock"
   - package-lock.json
-
-files:
-  - "**/*.md"
-  - "**/*.mdx"
-  - "docs/**"
-  - "website/**"
 
 ignoreRegExpList:
   - "/https?:\\/\\/[^\\s)]+/g"


### PR DESCRIPTION
## Summary
- narrow CSpell scope to markdown and MDX content only
- exclude non-documentation assets and code files from CSpell config
- add valid repository-specific words to the shared dictionary
- keep PR checks incremental and main branch checks full-surface

## Testing
- removes false positives from SVG and JavaScript files
- keeps spell checking focused on documentation content
- preserves Docusaurus-only governance guard behavior

## Related
- #68