### PR TITLE
feat(ci): add automatic PR labeling based on changed paths

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,8 +1,47 @@
+---
+area:ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**"
+          - ".github/actions/**"
+          - "scripts/**"
+          - "config/**"
+
+area:repo:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"
+          - "README.md"
+          - "CONTRIBUTING.md"
+          - "CODE_OF_CONDUCT.md"
+          - "SECURITY.md"
+          - ".pre-commit-config.yaml"
+          - ".commitlintrc*"
+          - "commitlint.config.*"
+          - ".editorconfig"
+          - ".gitignore"
+          - "package.json"
+          - "package-lock.json"
+          - "pyproject.toml"
+          - "requirements*.txt"
+
+area:security:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**"
+          - "SECURITY.md"
+          - "gitleaks*"
+          - ".gitleaks*"
+          - "security/**"
+
 area:theme:
   - changed-files:
       - any-glob-to-any-file:
-          - "website/src/**"
+          - "website/src/css/**"
+          - "website/src/theme/**"
+          - "website/src/components/**"
           - "website/static/**"
+          - "website/docusaurus.config.*"
 
 area:labs:
   - changed-files:
@@ -22,20 +61,11 @@ area:case-studies:
 area:external-docs:
   - changed-files:
       - any-glob-to-any-file:
-          - "website/docs/**"
+          - "website/docs/external-docs/**"
 
 area:repo-docs:
   - changed-files:
       - any-glob-to-any-file:
           - "docs/**"
-
-area:repo:
-  - changed-files:
-      - any-glob-to-any-file:
-          - ".github/**"
-          - "scripts/**"
-
-area:ci:
-  - changed-files:
-      - any-glob-to-any-file:
-          - ".github/workflows/**"
+          - "website/docs/governance/**"
+          - "website/docs/reference/**"

--- a/.github/workflows/pr-auto-label.yml
+++ b/.github/workflows/pr-auto-label.yml
@@ -2,8 +2,12 @@
 name: PR Auto Label
 
 "on":
-  pull_request:
-    types: [opened, synchronize, reopened]
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
 
 permissions:
   contents: read
@@ -11,12 +15,9 @@ permissions:
 
 jobs:
   label:
+    name: Apply path-based labels
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
-
-      - name: Apply labels
-        uses: actions/labeler@v6
-        with:
-          configuration-path: .github/labeler.yml
+      - name: Apply labels from changed paths
+        uses: actions/labeler@v5


### PR DESCRIPTION
## Summary
Add automatic PR labeling based on changed file paths.

## Why
This aligns pull request labeling with the repository's area taxonomy and reduces manual triage work.

## Changes
- update PR auto-label workflow
- add path-based label configuration
- map changed paths to area labels
- keep PR labeling responsibility in a single workflow

## Validation
- verified workflow configuration
- verified labeler config structure
- aligned behavior with existing governance decisions

## Related Issues
- Closes #66
