### PR TITLE
feat(governance): add ADR template (#128)

### DIFF
--- a/docs/governance/adr-template.md
+++ b/docs/governance/adr-template.md
@@ -1,0 +1,72 @@
+# ADR Template
+
+This file defines the canonical Architecture Decision Record (ADR) template.
+
+---
+
+## Filename Convention
+
+adr-XXX-short-title.md
+
+Example:
+adr-001-use-docusaurus.md
+
+---
+
+## Frontmatter
+
+```yaml
+title: string
+description: string
+content_type: adr
+status: draft | review | active | deprecated | archived
+tags: [string]
+owners: ["@github-username"]
+created_at: YYYY-MM-DD
+last_reviewed: YYYY-MM-DD
+primary_domain: governance
+adr_id: ADR-XXX
+decision: string
+context: string
+consequences: string
+```
+
+---
+
+## Required Sections
+
+## Title
+
+Short descriptive title of the decision.
+
+## Status
+
+Current lifecycle status.
+
+## Context
+
+What problem are we solving?
+
+## Decision
+
+What was decided?
+
+## Consequences
+
+What are the results, trade-offs, and impacts?
+
+---
+
+## Optional Sections
+
+### Alternatives Considered
+
+Other options evaluated.
+
+### Risks
+
+Known risks associated with the decision.
+
+### Notes
+
+Additional context or references.

--- a/docs/governance/content-contract.md
+++ b/docs/governance/content-contract.md
@@ -1,0 +1,72 @@
+# Content Contract
+
+This document defines the content contract for the Engineering Journal.
+
+It serves as both:
+
+- a validation specification (for CI enforcement)
+- an authoring guide (for contributors)
+
+All content MUST comply with this contract.
+
+---
+
+## Core Requirements
+
+Every document MUST:
+
+- include valid frontmatter
+- use approved taxonomy values
+- follow lifecycle rules
+- include required structural sections
+
+---
+
+## Structural Requirements
+
+Each content type has required minimum sections.
+
+### Lab
+
+- Overview
+- Environment
+- Steps
+- Validation
+- Lessons Learned
+
+### Case Study
+
+- Summary
+- Problem
+- Impact
+- Root Cause
+- Resolution
+- Lessons Learned
+
+### Journal Entry
+
+- Summary
+- Notes
+- Insights
+
+### ADR
+
+- Title
+- Status
+- Context
+- Decision
+- Consequences
+
+---
+
+## Enforcement
+
+The contract is enforced via:
+
+- CI validation scripts
+- frontmatter validation
+- taxonomy validation
+- lifecycle validation
+- structural linting
+
+Violations MUST result in CI failure.


### PR DESCRIPTION
## Summary
Adds a canonical ADR template with required and optional sections.

## Changes
- Defined ADR frontmatter schema
- Added required sections (Title, Status, Context, Decision, Consequences)
- Added optional sections (Alternatives, Risks, Notes)
- Standardized ADR ID format (ADR-XXX)

## Why
Ensures:
- consistent architectural decision tracking
- enforceable governance
- scalable documentation practices

## Related
Closes #128