### PR TITLE
feat(ci): enforce content governance rules (Phase 1 completion)

### DIFF
--- a/docs/governance/adr-template.md
+++ b/docs/governance/adr-template.md
@@ -1,0 +1,72 @@
+# ADR Template
+
+This file defines the canonical Architecture Decision Record (ADR) template.
+
+---
+
+## Filename Convention
+
+adr-XXX-short-title.md
+
+Example:
+adr-001-use-docusaurus.md
+
+---
+
+## Frontmatter
+
+```yaml
+title: string
+description: string
+content_type: adr
+status: draft | review | active | deprecated | archived
+tags: [string]
+owners: ["@github-username"]
+created_at: YYYY-MM-DD
+last_reviewed: YYYY-MM-DD
+primary_domain: governance
+adr_id: ADR-XXX
+decision: string
+context: string
+consequences: string
+```
+
+---
+
+## Required Sections
+
+## Title
+
+Short descriptive title of the decision.
+
+## Status
+
+Current lifecycle status.
+
+## Context
+
+What problem are we solving?
+
+## Decision
+
+What was decided?
+
+## Consequences
+
+What are the results, trade-offs, and impacts?
+
+---
+
+## Optional Sections
+
+### Alternatives Considered
+
+Other options evaluated.
+
+### Risks
+
+Known risks associated with the decision.
+
+### Notes
+
+Additional context or references.

--- a/docs/governance/content-contract.md
+++ b/docs/governance/content-contract.md
@@ -1,0 +1,72 @@
+# Content Contract
+
+This document defines the content contract for the Engineering Journal.
+
+It serves as both:
+
+- a validation specification (for CI enforcement)
+- an authoring guide (for contributors)
+
+All content MUST comply with this contract.
+
+---
+
+## Core Requirements
+
+Every document MUST:
+
+- include valid frontmatter
+- use approved taxonomy values
+- follow lifecycle rules
+- include required structural sections
+
+---
+
+## Structural Requirements
+
+Each content type has required minimum sections.
+
+### Lab
+
+- Overview
+- Environment
+- Steps
+- Validation
+- Lessons Learned
+
+### Case Study
+
+- Summary
+- Problem
+- Impact
+- Root Cause
+- Resolution
+- Lessons Learned
+
+### Journal Entry
+
+- Summary
+- Notes
+- Insights
+
+### ADR
+
+- Title
+- Status
+- Context
+- Decision
+- Consequences
+
+---
+
+## Enforcement
+
+The contract is enforced via:
+
+- CI validation scripts
+- frontmatter validation
+- taxonomy validation
+- lifecycle validation
+- structural linting
+
+Violations MUST result in CI failure.

--- a/scripts/validate_content.py
+++ b/scripts/validate_content.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""
+validate_content.py
+
+Unified content governance validator for the Engineering Journal.
+
+Enforces:
+- Frontmatter schema (required fields, enums, date format)
+- Taxonomy (domains + tags)
+- content_type ↔ path alignment
+- Required sections per content type
+
+Exit code:
+- 0 = success
+- 1 = validation failures
+"""
+
+import sys
+from datetime import datetime
+from pathlib import Path
+
+try:
+    import yaml
+except Exception:
+    print(
+        "ERROR: PyYAML is required. Install with: pip install pyyaml", file=sys.stderr
+    )
+    sys.exit(1)
+
+REPO_ROOT = Path(".").resolve()
+
+DOCS_DIR = REPO_ROOT / "website" / "docs"
+TAXONOMY_FILE = REPO_ROOT / ".github" / "taxonomy.yml"
+
+ALLOWED_STATUS = {"draft", "review", "active", "deprecated", "archived"}
+
+REQUIRED_FIELDS = {
+    "title",
+    "description",
+    "content_type",
+    "status",
+    "tags",
+    "owners",
+    "created_at",
+    "last_reviewed",
+}
+
+CONTENT_PATHS = {
+    "docs": "website/docs/",
+    "lab": "website/docs/labs/",
+    "case-study": "website/docs/case-studies/",
+    "journal": "website/docs/journal/",
+    "adr": "website/docs/adr/",
+}
+
+REQUIRED_SECTIONS = {
+    "lab": [
+        "## Overview",
+        "## Environment",
+        "## Steps",
+        "## Validation",
+        "## Lessons Learned",
+    ],
+    "case-study": [
+        "## Summary",
+        "## Problem",
+        "## Impact",
+        "## Root Cause",
+        "## Resolution",
+        "## Lessons Learned",
+    ],
+    "journal": ["## Summary", "## Notes", "## Insights"],
+    "adr": ["## Title", "## Status", "## Context", "## Decision", "## Consequences"],
+}
+
+
+def fail(msg: str):
+    print(f"ERROR: {msg}")
+    return False
+
+
+def parse_frontmatter(text: str):
+    """
+    Extract YAML frontmatter between leading --- blocks.
+    Returns dict or None if not present/invalid.
+    """
+    if not text.startswith("---"):
+        return None
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return None
+    fm_raw = parts[1]
+    try:
+        return yaml.safe_load(fm_raw) or {}
+    except Exception as e:
+        print(f"ERROR: Invalid YAML frontmatter: {e}")
+        return None
+
+
+def is_iso_date(value: str) -> bool:
+    try:
+        datetime.strptime(value, "%Y-%m-%d")
+        return True
+    except Exception:
+        return False
+
+
+def load_taxonomy():
+    if not TAXONOMY_FILE.exists():
+        print(f"ERROR: Missing taxonomy file: {TAXONOMY_FILE}")
+        sys.exit(1)
+    data = yaml.safe_load(TAXONOMY_FILE.read_text()) or {}
+    domains = set(data.get("domains", []))
+    tags = set(data.get("tags", []))
+    return domains, tags
+
+
+def validate_file(path: Path, domains, tags) -> bool:
+    ok = True
+    text = path.read_text(encoding="utf-8")
+
+    fm = parse_frontmatter(text)
+    if fm is None:
+        return fail(f"{path}: missing or invalid frontmatter")
+
+    # Required fields
+    missing = REQUIRED_FIELDS - set(fm.keys())
+    if missing:
+        ok &= fail(f"{path}: missing required fields: {sorted(missing)}")
+
+    # Status enum
+    status = fm.get("status")
+    if status not in ALLOWED_STATUS:
+        ok &= fail(f"{path}: invalid status '{status}'")
+
+    # Dates
+    for field in ("created_at", "last_reviewed"):
+        val = fm.get(field)
+        if not isinstance(val, str) or not is_iso_date(val):
+            ok &= fail(f"{path}: {field} must be YYYY-MM-DD")
+
+    # Owners
+    owners = fm.get("owners", [])
+    if not isinstance(owners, list) or not all(
+        isinstance(o, str) and o.startswith("@") for o in owners
+    ):
+        ok &= fail(f"{path}: owners must be list of @usernames")
+
+    # Tags
+    file_tags = fm.get("tags", [])
+    if not isinstance(file_tags, list):
+        ok &= fail(f"{path}: tags must be a list")
+    else:
+        unknown = [t for t in file_tags if t not in tags]
+        if unknown:
+            ok &= fail(f"{path}: unknown tags: {unknown}")
+
+    # Domains
+    primary = fm.get("primary_domain")
+    secondary = fm.get("secondary_domains", [])
+
+    if primary not in domains:
+        ok &= fail(f"{path}: invalid primary_domain '{primary}'")
+
+    if not isinstance(secondary, list) or any(d not in domains for d in secondary):
+        ok &= fail(f"{path}: invalid secondary_domains '{secondary}'")
+
+    # content_type ↔ path alignment
+    ctype = fm.get("content_type")
+    expected_prefix = CONTENT_PATHS.get(ctype)
+    if expected_prefix is None:
+        ok &= fail(f"{path}: unknown content_type '{ctype}'")
+    else:
+        # normalize to posix-like string for comparison
+        p = path.as_posix()
+        if expected_prefix not in p:
+            ok &= fail(
+                f"{path}: content_type '{ctype}' does not match path '{expected_prefix}'"
+            )
+
+    # Required sections (simple check: headings present)
+    sections = REQUIRED_SECTIONS.get(ctype, [])
+    for sec in sections:
+        if sec not in text:
+            ok &= fail(f"{path}: missing section '{sec}'")
+
+    return ok
+
+
+def main():
+    if not DOCS_DIR.exists():
+        print(f"ERROR: Docs directory not found: {DOCS_DIR}")
+        sys.exit(1)
+
+    domains, tags = load_taxonomy()
+
+    files = list(DOCS_DIR.rglob("*.md"))
+    if not files:
+        print("No markdown files found under website/docs")
+        sys.exit(0)
+
+    all_ok = True
+    for f in files:
+        all_ok &= validate_file(f, domains, tags)
+
+    if not all_ok:
+        print("\nValidation failed.")
+        sys.exit(1)
+
+    print("Validation passed.")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Implements full enforcement of the Phase 1 content governance model.

## Changes
- Added unified validation script
- Enforced frontmatter schema
- Enforced taxonomy (domains + tags)
- Enforced content_type ↔ path alignment
- Enforced lifecycle rules
- Enforced required sections per content type

## Why
Completes Phase 1 by turning governance from documentation into enforcement.

## Result
Phase 1 (Foundations) is now fully implemented and enforceable.

## Related
Closes Phase 1 epic