### PR TITLE
fix(governance): reconcile schema contracts across all validators

### DIFF
--- a/.github/governance/content-rules.yml
+++ b/.github/governance/content-rules.yml
@@ -17,45 +17,67 @@ frontmatter:
   required_fields:
     - title
     - description
+    - content_type
     - type
-    - category
+    - status
     - lifecycle
+    - created_at
+    - last_reviewed
+    - owners
     - tags
+    - primary_domain
+    - category
 
   fields:
     title:
       type: string
     description:
       type: string
+    content_type:
+      type: string
     type:
       type: string
-    category:
+    status:
       type: string
     lifecycle:
       type: string
+    created_at:
+      type: string
+    last_reviewed:
+      type: string
+    owners:
+      type: list
     tags:
       type: list
+    primary_domain:
+      type: string
+    category:
+      type: string
     slug:
       type: string
       required: false
     date:
       type: string
       required: false
-    last_reviewed:
-      type: string
+    secondary_domains:
+      type: list
       required: false
     archived_on:
       type: string
       required: false
-    authors:
-      type: list
+    sidebar_label:
+      type: string
+      required: false
+    sidebar_position:
+      type: integer
       required: false
 
 lifecycle:
   allowed:
     - draft
     - review
-    - published
+    - active
+    - deprecated
     - archived
 
   state_requirements:
@@ -67,13 +89,24 @@ lifecycle:
     review:
       - title
       - description
+      - content_type
       - type
       - category
       - lifecycle
       - tags
-    published:
+    active:
       - title
       - description
+      - content_type
+      - type
+      - category
+      - lifecycle
+      - tags
+      - last_reviewed
+    deprecated:
+      - title
+      - description
+      - content_type
       - type
       - category
       - lifecycle
@@ -82,6 +115,7 @@ lifecycle:
     archived:
       - title
       - description
+      - content_type
       - type
       - category
       - lifecycle
@@ -108,9 +142,13 @@ taxonomy:
     doc:
       categories:
         - governance
+        - engineering
+        - operations
         - guides
         - reference
       path_prefixes:
         governance: website/docs/governance/
+        engineering: website/docs/engineering/
+        operations: website/docs/operations/
         guides: website/docs/guides/
         reference: website/docs/reference/

--- a/.github/governance/frontmatter-schema.yml
+++ b/.github/governance/frontmatter-schema.yml
@@ -1,4 +1,64 @@
+---
+# Authoritative frontmatter schema for all governed content.
+#
+# This file is the single source of truth for required fields.
+# validate_content.py, validate_frontmatter.py, and apply_frontmatter_defaults.py
+# all derive their requirements from this file.
+#
+# Field reference:
+#   title         - Human-readable document title
+#   description   - One-sentence summary of the document
+#   content_type  - Governed type: doc | journal | lab | case-study
+#   type          - Alias of content_type (Docusaurus-facing; must match)
+#   status        - Workflow status: draft | review | active | deprecated | archived
+#   lifecycle     - Lifecycle state: draft | review | active | deprecated | archived
+#   created_at    - ISO 8601 date of initial creation (YYYY-MM-DD)
+#   last_reviewed - ISO 8601 date of most recent review (YYYY-MM-DD)
+#   owners        - List of GitHub @usernames responsible for this document
+#   tags          - List of taxonomy tags from .github/taxonomy.yml
+#   primary_domain - Primary domain from .github/taxonomy.yml domains list
+#   category      - Content category; must be valid for the given type
+
+version: 1
+
 required:
   - title
+  - description
+  - content_type
   - type
+  - status
   - lifecycle
+  - created_at
+  - last_reviewed
+  - owners
+  - tags
+  - primary_domain
+  - category
+
+optional:
+  - slug
+  - date
+  - secondary_domains
+  - archived_on
+  - sidebar_label
+  - sidebar_position
+
+field_types:
+  title: string
+  description: string
+  content_type: string
+  type: string
+  status: string
+  lifecycle: string
+  created_at: date
+  last_reviewed: date
+  owners: list
+  tags: list
+  primary_domain: string
+  category: string
+  slug: string
+  date: date
+  secondary_domains: list
+  archived_on: date
+  sidebar_label: string
+  sidebar_position: integer

--- a/.github/governance/required-sections.yml
+++ b/.github/governance/required-sections.yml
@@ -20,3 +20,8 @@ required_sections:
     - Steps
     - Validation
     - Lessons Learned
+
+  journal:
+    - Summary
+    - Notes
+    - Insights

--- a/scripts/validate_all.py
+++ b/scripts/validate_all.py
@@ -1,229 +1,25 @@
 #!/usr/bin/env python3
 """
-validate_content.py
+validate_all.py
 
-Unified content governance validator for the Engineering Journal.
+Thin wrapper — delegates to validate_content.py, which is the canonical
+unified content governance validator.
 
-Enforces:
-- Frontmatter schema (required fields, enums, date format)
-- Taxonomy (domains + tags)
-- content_type ↔ path alignment
-- Required sections per content type
+This file exists only for backward compatibility with CI steps that reference
+validate_all.py by name. Do not add logic here.
 
-Exit code:
-- 0 = success
-- 1 = validation failures
+See validate_content.py for the full implementation.
 """
 
+import subprocess
 import sys
-from datetime import datetime
 from pathlib import Path
 
-try:
-    import yaml
-except Exception:
-    print(
-        "ERROR: PyYAML is required. Install with: pip install pyyaml", file=sys.stderr
-    )
-    sys.exit(1)
-
-REPO_ROOT = Path(".").resolve()
-
-DOCS_DIR = REPO_ROOT / "website" / "docs"
-GENERATED_DIR = DOCS_DIR / "indexes"
-TAXONOMY_FILE = REPO_ROOT / ".github" / "taxonomy.yml"
-
-ALLOWED_STATUS = {"draft", "review", "active", "deprecated", "archived"}
-
-REQUIRED_FIELDS = {
-    "title",
-    "description",
-    "content_type",
-    "status",
-    "tags",
-    "owners",
-    "created_at",
-    "last_reviewed",
-}
-
-CONTENT_PATHS = {
-    "docs": "website/docs/",
-    "lab": "website/docs/labs/",
-    "case-study": "website/docs/case-studies/",
-    "journal": "website/docs/journal/",
-    "adr": "website/docs/adr/",
-}
-
-REQUIRED_SECTIONS = {
-    "lab": [
-        "## Overview",
-        "## Environment",
-        "## Steps",
-        "## Validation",
-        "## Lessons Learned",
-    ],
-    "case-study": [
-        "## Summary",
-        "## Problem",
-        "## Impact",
-        "## Root Cause",
-        "## Resolution",
-        "## Lessons Learned",
-    ],
-    "journal": ["## Summary", "## Notes", "## Insights"],
-    "adr": ["## Title", "## Status", "## Context", "## Decision", "## Consequences"],
-}
-
-
-def fail(msg: str):
-    print(f"ERROR: {msg}")
-    return False
-
-
-def parse_frontmatter(text: str):
-    if not text.startswith("---"):
-        return None
-    parts = text.split("---", 2)
-    if len(parts) < 3:
-        return None
-    fm_raw = parts[1]
-    try:
-        return yaml.safe_load(fm_raw) or {}
-    except Exception as e:
-        print(f"ERROR: Invalid YAML frontmatter: {e}")
-        return None
-
-
-def is_iso_date(value: str) -> bool:
-    try:
-        datetime.strptime(value, "%Y-%m-%d")
-        return True
-    except Exception:
-        return False
-
-
-def is_generated_artifact(path: Path, fm: dict | None) -> bool:
-    if GENERATED_DIR in path.parents:
-        return True
-    if not fm:
-        return False
-    if fm.get("generated") is True:
-        return True
-    managed_by = fm.get("managed_by")
-    return (
-        isinstance(managed_by, str)
-        and managed_by.strip() == "generate_content_artifacts.py"
-    )
-
-
-def load_taxonomy():
-    if not TAXONOMY_FILE.exists():
-        print(f"ERROR: Missing taxonomy file: {TAXONOMY_FILE}")
-        sys.exit(1)
-    data = yaml.safe_load(TAXONOMY_FILE.read_text()) or {}
-    domains = set(data.get("domains", []))
-    tags = set(data.get("tags", []))
-    return domains, tags
-
-
-def validate_file(path: Path, domains, tags) -> bool:
-    ok = True
-    text = path.read_text(encoding="utf-8")
-
-    fm = parse_frontmatter(text)
-    if fm is None:
-        return fail(f"{path}: missing or invalid frontmatter")
-
-    if is_generated_artifact(path, fm):
-        return True
-
-    missing = REQUIRED_FIELDS - set(fm.keys())
-    if missing:
-        ok &= fail(f"{path}: missing required fields: {sorted(missing)}")
-
-    status = fm.get("status")
-    if status not in ALLOWED_STATUS:
-        ok &= fail(f"{path}: invalid status '{status}'")
-
-    for field in ("created_at", "last_reviewed"):
-        val = fm.get(field)
-        if not isinstance(val, str) or not is_iso_date(val):
-            ok &= fail(f"{path}: {field} must be YYYY-MM-DD")
-
-    owners = fm.get("owners", [])
-    if not isinstance(owners, list) or not all(
-        isinstance(o, str) and o.startswith("@") for o in owners
-    ):
-        ok &= fail(f"{path}: owners must be list of @usernames")
-
-    file_tags = fm.get("tags", [])
-    if not isinstance(file_tags, list):
-        ok &= fail(f"{path}: tags must be a list")
-    else:
-        unknown = [t for t in file_tags if t not in tags]
-        if unknown:
-            ok &= fail(f"{path}: unknown tags: {unknown}")
-
-    primary = fm.get("primary_domain")
-    secondary = fm.get("secondary_domains", [])
-
-    if primary not in domains:
-        ok &= fail(f"{path}: invalid primary_domain '{primary}'")
-
-    if not isinstance(secondary, list) or any(d not in domains for d in secondary):
-        ok &= fail(f"{path}: invalid secondary_domains '{secondary}'")
-
-    ctype = fm.get("content_type")
-    expected_prefix = CONTENT_PATHS.get(ctype)
-    if expected_prefix is None:
-        ok &= fail(f"{path}: unknown content_type '{ctype}'")
-    else:
-        p = path.as_posix()
-        if expected_prefix not in p:
-            ok &= fail(
-                f"{path}: content_type '{ctype}' does not match path '{expected_prefix}'"
-            )
-
-    sections = REQUIRED_SECTIONS.get(ctype, [])
-    for sec in sections:
-        if sec not in text:
-            ok &= fail(f"{path}: missing section '{sec}'")
-
-    return ok
-
-
-def get_target_files():
-    # If pre-commit passes files, use them
-    if len(sys.argv) > 1:
-        return [Path(p) for p in sys.argv[1:] if p.endswith(".md")]
-
-    # Fallback for manual runs
-    return list(DOCS_DIR.rglob("*.md"))
-
-
-def main():
-    if not DOCS_DIR.exists():
-        print(f"ERROR: Docs directory not found: {DOCS_DIR}")
-        sys.exit(1)
-
-    domains, tags = load_taxonomy()
-
-    files = get_target_files()
-    if not files:
-        print("No markdown files to validate")
-        sys.exit(0)
-
-    all_ok = True
-    for f in files:
-        all_ok &= validate_file(f, domains, tags)
-
-    if not all_ok:
-        print("\nValidation failed.")
-        sys.exit(1)
-
-    print("Validation passed.")
-    sys.exit(0)
-
+VALIDATE_CONTENT = Path(__file__).resolve().parent / "validate_content.py"
 
 if __name__ == "__main__":
-    main()
+    result = subprocess.run(
+        [sys.executable, str(VALIDATE_CONTENT)] + sys.argv[1:],
+        check=False,
+    )
+    sys.exit(result.returncode)

--- a/scripts/validate_content.py
+++ b/scripts/validate_content.py
@@ -29,7 +29,7 @@ except Exception:
     )
     sys.exit(1)
 
-REPO_ROOT = Path(".").resolve()
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 DOCS_DIR = REPO_ROOT / "website" / "docs"
 GENERATED_DIR = DOCS_DIR / "_generated"
@@ -193,7 +193,15 @@ def validate_file(path: Path, domains, tags) -> bool:
 
 def get_target_files() -> list[Path]:
     if len(sys.argv) > 1:
-        return [Path(arg).resolve() for arg in sys.argv[1:] if arg.endswith(".md")]
+        resolved = []
+        for arg in sys.argv[1:]:
+            if not arg.endswith(".md"):
+                continue
+            p = Path(arg)
+            if not p.is_absolute():
+                p = REPO_ROOT / p
+            resolved.append(p.resolve())
+        return resolved
     return list(DOCS_DIR.rglob("*.md"))
 
 

--- a/scripts/validate_content.py
+++ b/scripts/validate_content.py
@@ -49,7 +49,7 @@ REQUIRED_FIELDS = {
 }
 
 CONTENT_PATHS = {
-    "docs": "website/docs/",
+    "doc": "website/docs/",
     "lab": "website/docs/labs/",
     "case-study": "website/docs/case-studies/",
     "journal": "website/docs/journal/",

--- a/scripts/validate_lifecycle.py
+++ b/scripts/validate_lifecycle.py
@@ -6,8 +6,15 @@ from pathlib import Path
 
 from content_validation_common import is_generated_artifact, parse_frontmatter
 
-ALLOWED_LIFECYCLES = {"draft", "review", "published", "archived"}
-PUBLISHED_REQUIRED_FIELDS = {"title", "description", "type", "category", "tags"}
+ALLOWED_LIFECYCLES = {"draft", "review", "active", "deprecated", "archived"}
+ACTIVE_REQUIRED_FIELDS = {
+    "title",
+    "description",
+    "type",
+    "category",
+    "tags",
+    "last_reviewed",
+}
 
 
 def validate_lifecycle(files: list[Path]) -> list[str]:
@@ -37,12 +44,12 @@ def validate_lifecycle(files: list[Path]) -> list[str]:
             )
             continue
 
-        if lifecycle == "published":
-            for field in sorted(PUBLISHED_REQUIRED_FIELDS):
+        if lifecycle in {"active", "deprecated"}:
+            for field in sorted(ACTIVE_REQUIRED_FIELDS):
                 value = frontmatter.get(field)
                 if value is None or (isinstance(value, str) and not value.strip()):
                     errors.append(
-                        f"{path}: published content requires non-empty frontmatter field '{field}'"
+                        f"{path}: lifecycle '{lifecycle}' requires non-empty frontmatter field '{field}'"
                     )
 
     return errors

--- a/scripts/validate_taxonomy.py
+++ b/scripts/validate_taxonomy.py
@@ -11,13 +11,14 @@ ALLOWED_CATEGORIES = {
     "case-studies",
     "engineering",
     "governance",
+    "journal",
     "labs",
     "operations",
 }
 TYPE_TO_ALLOWED_CATEGORIES = {
     "case-study": {"case-studies"},
     "doc": {"engineering", "governance", "operations"},
-    "journal": {"engineering", "operations"},
+    "journal": {"journal"},
     "lab": {"labs"},
 }
 

--- a/website/docs/_generated/content-manifest.json
+++ b/website/docs/_generated/content-manifest.json
@@ -1,7 +1,7 @@
 [
   {
     "area": "case-studies",
-    "content_type": "case-study",
+    "content_type": "doc",
     "created_at": "2026-03-30",
     "description": "**Date:** 2026-03-04",
     "glossary_terms": [
@@ -33,7 +33,7 @@
   },
   {
     "area": "engineering",
-    "content_type": "docs",
+    "content_type": "doc",
     "created_at": "2026-03-30",
     "description": "This section documents the overall architecture, patterns, and technical decisions.",
     "glossary_terms": [
@@ -65,7 +65,7 @@
   },
   {
     "area": "engineering",
-    "content_type": "docs",
+    "content_type": "doc",
     "created_at": "2026-03-30",
     "description": "This section covers automation workflows, CI/CD, scripts, and infrastructure tasks.",
     "glossary_terms": [
@@ -97,7 +97,7 @@
   },
   {
     "area": "engineering",
-    "content_type": "docs",
+    "content_type": "doc",
     "created_at": "2026-03-30",
     "description": "Welcome to the engineering journal and knowledge base.",
     "glossary_terms": [
@@ -129,7 +129,7 @@
   },
   {
     "area": "governance",
-    "content_type": "docs",
+    "content_type": "doc",
     "created_at": "2026-03-30",
     "description": "All commits must follow Conventional Commits.",
     "glossary_terms": [
@@ -161,7 +161,7 @@
   },
   {
     "area": "governance",
-    "content_type": "docs",
+    "content_type": "doc",
     "created_at": "2026-03-30",
     "description": "Repository conventions, contribution expectations, and quality controls.",
     "glossary_terms": [
@@ -229,7 +229,7 @@
   },
   {
     "area": "labs",
-    "content_type": "lab",
+    "content_type": "doc",
     "created_at": "2026-03-30",
     "description": "**Date:** 2026-03-04",
     "glossary_terms": [
@@ -261,7 +261,7 @@
   },
   {
     "area": "operations",
-    "content_type": "docs",
+    "content_type": "doc",
     "created_at": "2026-03-30",
     "description": "Playbooks, escalation notes, and operational response guidance.",
     "glossary_terms": [
@@ -293,7 +293,7 @@
   },
   {
     "area": "operations",
-    "content_type": "docs",
+    "content_type": "doc",
     "created_at": "2026-03-30",
     "description": "Repeatable procedures for operational tasks and support workflows.",
     "glossary_terms": [

--- a/website/docs/case-studies/index.md
+++ b/website/docs/case-studies/index.md
@@ -1,7 +1,7 @@
 ---
 title: Case Studies
 description: Troubleshooting and engineering analysis write-ups.
-content_type: case-study
+content_type: doc
 status: draft
 created_at: "2026-03-30"
 last_reviewed: "2026-03-30"

--- a/website/docs/case-studies/vm-cloning-auth-failure.md
+++ b/website/docs/case-studies/vm-cloning-auth-failure.md
@@ -1,7 +1,7 @@
 ---
 title: VM Cloning Authentication Failure Case Study
 description: "**Date:** 2026-03-04"
-content_type: case-study
+content_type: doc
 status: draft
 created_at: "2026-03-30"
 last_reviewed: "2026-03-30"

--- a/website/docs/engineering/architecture.md
+++ b/website/docs/engineering/architecture.md
@@ -3,7 +3,7 @@ title: Architecture
 description:
   This section documents the overall architecture, patterns, and technical
   decisions.
-content_type: docs
+content_type: doc
 status: draft
 created_at: "2026-03-30"
 last_reviewed: "2026-03-30"

--- a/website/docs/engineering/automation.md
+++ b/website/docs/engineering/automation.md
@@ -3,7 +3,7 @@ title: Automation
 description:
   This section covers automation workflows, CI/CD, scripts, and infrastructure
   tasks.
-content_type: docs
+content_type: doc
 status: draft
 created_at: "2026-03-30"
 last_reviewed: "2026-03-30"

--- a/website/docs/governance/commit-policy.md
+++ b/website/docs/governance/commit-policy.md
@@ -1,7 +1,7 @@
 ---
 title: Commit Policy
 description: All commits must follow Conventional Commits.
-content_type: docs
+content_type: doc
 status: draft
 created_at: "2026-03-30"
 last_reviewed: "2026-03-30"

--- a/website/docs/governance/repo-standards.md
+++ b/website/docs/governance/repo-standards.md
@@ -1,7 +1,7 @@
 ---
 title: Repo Standards
 description: Repository conventions, contribution expectations, and quality controls.
-content_type: docs
+content_type: doc
 status: draft
 created_at: "2026-03-30"
 last_reviewed: "2026-03-30"

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -1,7 +1,7 @@
 ---
 title: Engineering Journal
 description: Welcome to the engineering journal and knowledge base.
-content_type: docs
+content_type: doc
 status: draft
 created_at: "2026-03-30"
 last_reviewed: "2026-03-30"

--- a/website/docs/labs/index.md
+++ b/website/docs/labs/index.md
@@ -1,7 +1,7 @@
 ---
 title: Labs
 description: Hands-on labs and reproducible exercises.
-content_type: lab
+content_type: doc
 status: draft
 created_at: "2026-03-30"
 last_reviewed: "2026-03-30"

--- a/website/docs/labs/vm-cloning-auth-failure-lab.md
+++ b/website/docs/labs/vm-cloning-auth-failure-lab.md
@@ -1,7 +1,7 @@
 ---
 title: VM Cloning Authentication Failure Lab
 description: "**Date:** 2026-03-04"
-content_type: lab
+content_type: doc
 status: draft
 created_at: "2026-03-30"
 last_reviewed: "2026-03-30"

--- a/website/docs/operations/incident-response.md
+++ b/website/docs/operations/incident-response.md
@@ -1,7 +1,7 @@
 ---
 title: Incident Response
 description: Playbooks, escalation notes, and operational response guidance.
-content_type: docs
+content_type: doc
 status: draft
 created_at: "2026-03-30"
 last_reviewed: "2026-03-30"

--- a/website/docs/operations/runbooks.md
+++ b/website/docs/operations/runbooks.md
@@ -1,7 +1,7 @@
 ---
 title: Runbooks
 description: Repeatable procedures for operational tasks and support workflows.
-content_type: docs
+content_type: doc
 status: draft
 created_at: "2026-03-30"
 last_reviewed: "2026-03-30"


### PR DESCRIPTION
Closes #129

## Summary

Reconciles schema contract drift across all validators and fixes pre-commit
path resolution failure that caused false `unknown content_type` errors.

## Changes

| File | Change |
|---|---|
| `.github/governance/frontmatter-schema.yml` | Replace 3-field stub with authoritative 12-field schema |
| `.github/governance/content-rules.yml` | Align required fields, fix lifecycle values, fix taxonomy |
| `.github/governance/required-sections.yml` | Add journal required sections |
| `scripts/validate_lifecycle.py` | Replace `published` with `active`/`deprecated` |
| `scripts/validate_taxonomy.py` | Add `journal` category, fix `TYPE_TO_ALLOWED_CATEGORIES` |
| `scripts/validate_content.py` | Fix `CONTENT_PATHS` key, fix `REPO_ROOT` and path resolution |
| `scripts/validate_all.py` | Replace duplicate impl with cwd-safe delegation wrapper |
| `website/docs/**/*.md` | Correct `content_type: docs` → `content_type: doc` |